### PR TITLE
Add awesome_bot with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-redirect
+  - awesome_bot README.md --allow-redirect --allow-ssl
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md
+  - awesome_bot README.md --allow-redirect
 notifications:
   email: false


### PR DESCRIPTION
Add awesome_bot to improve awesome-design with `--allow-redirect --allow-ssl` options.
Could you setup it on your travis dashboard?

I got following issues. 
Ref: https://travis-ci.org/serima/awesome-design/builds/159200725

```
Issues :-(
> Links 
  1. [L139] 404 http://svgporn.com/  
  2. [L314]  http://www.axure.com/ incorrect header check 
> Dupes 
  1. [L218] https://www.fonts.com/
  2. [L219] https://www.fontsquirrel.com/
  3. [L243] https://icons8.com/
```