### PR TITLE
Add ColorTools to Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ No need to mention the author.
 - [Chinese Colors](http://zhongguose.com) is a collection of Chinese traditional colors.
 - [Gradienta](https://gradienta.io/) Multicolor CSS Gradients, JPG Downloads, 100% Free!
 - [Veranda Color](https://verandacolor.com) Browse color palettes made by other designers, generate and submit your own.
+- [ColorTools](https://colorpicker.cx/) Free color picker from image, color wheel, palette generator, CSS gradient builder and WCAG contrast checker.
 
 ## Icon and Logo
 


### PR DESCRIPTION
Adds ColorTools (https://colorpicker.cx/) to the Color section - a free, no sign-up suite of color tools: image color picker, color wheel with harmony rules, palette generator, CSS gradient builder and WCAG contrast checker.